### PR TITLE
Add /?/init.lua to loaders

### DIFF
--- a/includes/modules/require.lua
+++ b/includes/modules/require.lua
@@ -85,6 +85,11 @@ package.loaders = {
 	function(name)
 		return loadluamodule(name, "libraries/" .. string.gsub(name, "%.", "/") .. ".lua")
 	end,
+	
+	-- try to fetch the pure Lua module from lua/libraries/.../init.lua ("à la" Lua 5.1)
+	function(name)
+		return loadluamodule(name, "libraries/" .. string.gsub(name, "%.", "/") .. "/init.lua")
+	end,
 
 	-- try to fetch the binary module from lua/bin ("à la" Garry's Mod)
 	function(name)


### PR DESCRIPTION
so when we require('mod') it will try libraries/mod.lua, libraries/mod/init.lua

default luajit package.path has
/usr/share/lua/5.1/?.lua
/usr/share/lua/5.1/?/init.lua