### PR TITLE
Fix crashing from calling loadlib more than once on the same dll

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -106,7 +106,7 @@ LUA_FUNCTION( loadlib )
 	GarrysMod::Lua::CFunc func = nullptr;
 	if( !LUA->IsType( -1, GarrysMod::Lua::Type::NIL ) )
 	{
-		void *libhandle = LUA->GetUserType<void *>( -1, GarrysMod::Lua::Type::USERDATA );
+		void *libhandle = LUA->GetUserType<void>( -1, GarrysMod::Lua::Type::USERDATA );
 
 		func = FindFunction( libhandle, LUA->GetString( 2 ) );
 		if( func == nullptr )

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -106,9 +106,9 @@ LUA_FUNCTION( loadlib )
 	GarrysMod::Lua::CFunc func = nullptr;
 	if( !LUA->IsType( -1, GarrysMod::Lua::Type::NIL ) )
 	{
-		void **libhandle = LUA->GetUserType<void *>( -1, GarrysMod::Lua::Type::USERDATA );
+		void *libhandle = LUA->GetUserType<void *>( -1, GarrysMod::Lua::Type::USERDATA );
 
-		func = FindFunction( *libhandle, LUA->GetString( 2 ) );
+		func = FindFunction( libhandle, LUA->GetString( 2 ) );
 		if( func == nullptr )
 			return PushSystemError( LUA, "no_func" );
 	}


### PR DESCRIPTION
I ran into this bug from trying to `require("cqueues")` which runs
```lua
	local core = require"_cqueues"
	local errno = require"_cqueues.errno"
```
where `_cqueues` is `_cqueues.so`

The require() here will call
```
loadlib("_cqueues.so", "luaopen__cqueues", false)
then
loadlib("_cqueues.so", "luaopen__cqueues_errno", false) <-- crash here
```
and proceed to crash
